### PR TITLE
Re-export xcb::Atom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
 use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
-use xcb::{ Connection, Window, Atom };
+use xcb::{ Connection, Window };
+pub use xcb::Atom;
 
 
 pub const INCR_CHUNK_SIZE: usize = 4000;


### PR DESCRIPTION
This library references `Atom` pretty much everywhere, but it is missing from docs. Re-export makes it visible and allows for usage of library without ever touching `xcb` itself.