### PR TITLE
Removed failure, refactored error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ license = "MIT"
 travis-ci = { repository = "quininer/x11-clipboard" }
 
 [dependencies]
-failure = "0.1"
 xcb = { version = "0.8", features = [ "thread" ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use] extern crate failure;
 pub extern crate xcb;
 
 pub mod error;
@@ -9,8 +8,8 @@ use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
 use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
-use xcb::{ Connection, Window, Atom };
-
+use xcb::{ Connection, Window, Atom, base::ConnError};
+use error::Error;
 
 pub const INCR_CHUNK_SIZE: usize = 4000;
 const POLL_DURATION: u64 = 50;
@@ -42,7 +41,7 @@ pub struct Context {
 }
 
 #[inline]
-fn get_atom(connection: &Connection, name: &str) -> error::Result<Atom> {
+fn get_atom(connection: &Connection, name: &str) -> Result<Atom, Error> {
     xcb::intern_atom(connection, false, name)
         .get_reply()
         .map(|reply| reply.atom())
@@ -50,13 +49,13 @@ fn get_atom(connection: &Connection, name: &str) -> error::Result<Atom> {
 }
 
 impl Context {
-    pub fn new(displayname: Option<&str>) -> error::Result<Self> {
+    pub fn new(displayname: Option<&str>) -> Result<Self, Error> {
         let (connection, screen) = Connection::connect(displayname)?;
         let window = connection.generate_id();
 
         {
             let screen = connection.get_setup().roots().nth(screen as usize)
-                .ok_or(error::Error::XcbConn(::xcb::ConnError::ClosedInvalidScreen))?;
+                .ok_or(Error::XcbConn(ConnError::ClosedInvalidScreen))?;
             xcb::create_window(
                 &connection,
                 xcb::COPY_FROM_PARENT as u8,
@@ -92,7 +91,7 @@ impl Context {
         Ok(Context { connection, window, atoms })
     }
 
-    pub fn get_atom(&self, name: &str) -> error::Result<Atom> {
+    pub fn get_atom(&self, name: &str) -> Result<Atom, Error> {
         get_atom(&self.connection, name)
     }
 }
@@ -100,7 +99,7 @@ impl Context {
 
 impl Clipboard {
     /// Create Clipboard.
-    pub fn new() -> error::Result<Self> {
+    pub fn new() -> Result<Self, Error> {
         let getter = Context::new(None)?;
         let setter = Arc::new(Context::new(None)?);
         let setter2 = Arc::clone(&setter);
@@ -116,7 +115,7 @@ impl Clipboard {
 
     /// load value.
     pub fn load<T>(&self, selection: Atom, target: Atom, property: Atom, timeout: T)
-        -> error::Result<Vec<u8>>
+        -> Result<Vec<u8>, Error>
         where T: Into<Option<Duration>>
     {
         let mut buff = Vec::new();
@@ -141,9 +140,9 @@ impl Clipboard {
                 .zip(start_time)
                 .next()
                 .map(|(timeout, time)| (Instant::now() - time) >= timeout)
-                .unwrap_or(false)
+                .is_some()
             {
-                return Err(error::Error::Timeout);
+                return Err(Error::Timeout);
             }
 
             let event = match self.getter.connection.poll_for_event() {
@@ -218,11 +217,13 @@ impl Clipboard {
     }
 
     /// store value.
-    pub fn store<T: Into<Vec<u8>>>(&self, selection: Atom, target: Atom, value: T) -> error::Result<()> {
+    pub fn store<T: Into<Vec<u8>>>(&self, selection: Atom, target: Atom, value: T) 
+    -> Result<(), Error> 
+    {
         self.send.send(selection)?;
         self.setmap
             .write()
-            .map_err(|_| error::Error::Lock)?
+            .map_err(|_| Error::Lock)?
             .insert(selection, (target, value.into()));
 
         xcb::set_selection_owner(
@@ -230,16 +231,17 @@ impl Clipboard {
             self.setter.window, selection,
             xcb::CURRENT_TIME
         );
+
         self.setter.connection.flush();
 
         if xcb::get_selection_owner(&self.setter.connection, selection)
             .get_reply()
             .map(|reply| reply.owner() == self.setter.window)
-            .unwrap_or(false)
+            .is_ok()
         {
             Ok(())
         } else {
-            Err(error::Error::Owner)
+            Err(Error::Owner)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
 use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
-use xcb::{ Connection, Window, Atom, base::ConnError};
+use xcb::{ Connection, Window, Atom };
+use xcb::base::ConnError;
 use error::Error;
 
 pub const INCR_CHUNK_SIZE: usize = 4000;
@@ -140,7 +141,7 @@ impl Clipboard {
                 .zip(start_time)
                 .next()
                 .map(|(timeout, time)| (Instant::now() - time) >= timeout)
-                .is_some()
+                .unwrap_or(false)
             {
                 return Err(Error::Timeout);
             }
@@ -237,7 +238,7 @@ impl Clipboard {
         if xcb::get_selection_owner(&self.setter.connection, selection)
             .get_reply()
             .map(|reply| reply.owner() == self.setter.window)
-            .is_ok()
+            .unwrap_or(false)
         {
             Ok(())
         } else {

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 use xcb::{ self, Atom };
 use ::{ INCR_CHUNK_SIZE, Context, SetMap };
 
-
-
 macro_rules! try_continue {
     ( $expr:expr ) => {
         match $expr {
@@ -22,7 +20,6 @@ struct IncrState {
     property: Atom,
     pos: usize
 }
-
 
 pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver: &Receiver<Atom>) {
     let mut incr_map = HashMap::new();


### PR DESCRIPTION
For libraries, it's generally a good idea to not use failure, since failure depends on backtrace, which adds heaps and heaps of transitive build dependencies. Failure is good for CLI apps, but less libraries. The only reason that failure was used here was to avoid writing a single `Display` implementation block and I don't think that that justifies bringing in 50 external dependencies. 

Instead of `.unwrap_or(false)`, I've refactored this to `.is_some()` or `.is_ok()` respectively. And I've cleaned up the imports a bit. I removed the `error::Result<T>` because it doesn't really save any typing - in any other modules, you now have to type `-> error::Result<T>` instead of `Result<T, Error>` - the aliasing makes the returned type less clear and doesn't really do much in terms of saving typing.

You might not agree with all of these choices and that's fine. I'm currently putting together a more powerful clipboard library than `rust-clipboard`, especially in regards to handling the MIME type of a clipboard, which is why I needed this library. If you don't like my approach, just reject the PR, but if you accept it, please publish a new version of `x11-keyboard`.