### PR TITLE
Storing multiple targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,13 +292,50 @@ impl Clipboard {
         Ok(buff)
     }
 
-    /// store value.
+    /// Store a single value with a single target.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// extern crate x11_clipboard;
+    /// use x11_clipboard::Clipboard;
+    /// use std::time::Instant;
+    /// 
+    /// let data = format!("{:?}", Instant::now());
+    /// let clipboard = Clipboard::new().unwrap();
+    /// 
+    /// let atom_clipboard = clipboard.setter.atoms.clipboard;
+    /// let atom_utf8string = clipboard.setter.atoms.utf8_string;
+    /// 
+    /// clipboard.store(atom_clipboard, atom_utf8string, data.as_bytes()).unwrap();
+    /// ``` 
     pub fn store<T: Into<Vec<u8>>>(&self, selection: Atom, target: Atom, value: T)
         -> Result<(), Error>
     {
         self.store_many(selection, HashMap::from_iter([(target, value.into())]))
     }
 
+    /// Store values with multiple different targets.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// extern crate x11_clipboard;
+    /// use x11_clipboard::{xcb::intern_atom, Clipboard};
+    /// use std::collections::HashMap;
+    /// use std::time::Instant;
+    /// 
+    /// let clipboard = Clipboard::new().unwrap();
+    /// 
+    /// let atom_clipboard = clipboard.setter.atoms.clipboard;
+    /// let atom_utf8string = clipboard.setter.atoms.utf8_string;
+    /// let atom_text_plain = intern_atom(&clipboard.setter.connection, false, "text/plain").get_reply().unwrap().atom();
+    /// 
+    /// let mut data = HashMap::new();
+    /// data.insert(atom_utf8string, format!("{:?}", Instant::now()).into());
+    /// data.insert(atom_text_plain, "plaintext".into());
+    /// clipboard.store_many(atom_clipboard, data).unwrap();
+    /// ```
     pub fn store_many(&self, selection: SelectionAtom, target_values: HashMap<TargetAtom, Vec<u8>>) -> Result<(), Error> {
         self.send.send(selection)?;
         self.setmap

--- a/tests/multiple-targets.rs
+++ b/tests/multiple-targets.rs
@@ -1,0 +1,34 @@
+extern crate x11_clipboard;
+
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::time::{ Instant };
+use x11_clipboard::Clipboard;
+use x11_clipboard::xcb::{Atom, intern_atom};
+
+
+#[test]
+fn test_multiple_targets() {
+    let utf8_data = format!("{:?}", Instant::now());
+    let alt_data = "foobar";
+    let clipboard = Clipboard::new().unwrap();
+
+    let atom_clipboard = clipboard.setter.atoms.clipboard;
+    let atom_utf8string = clipboard.setter.atoms.utf8_string;
+    let atom_property = clipboard.setter.atoms.property;
+
+    let atom_foobar = intern_atom(&clipboard.setter.connection, false, "foobar").get_reply().unwrap().atom();
+
+    let data: HashMap<Atom, Vec<u8>> = HashMap::from_iter([
+        (atom_utf8string, utf8_data.as_bytes().to_owned()),
+        (atom_foobar, alt_data.as_bytes().to_owned())
+    ]);
+
+    clipboard.store_many(atom_clipboard, data).unwrap();
+
+    let stored_utf8_data = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    assert_eq!(utf8_data.as_bytes(), &stored_utf8_data);
+
+    let stored_foobar_data = clipboard.load(atom_clipboard, atom_foobar, atom_property, None).unwrap();
+    assert_eq!(alt_data.as_bytes(), &stored_foobar_data);
+}


### PR DESCRIPTION
Add support for storing (clipping) multiple target-value pairs to the selection.

When implementing this I had to change the functionality such that SelectionRequests for unknown targets are ignored, because there's no longer a simple way to paste something anyway - we can't really guess which target would be the best in this situation. Originally this change was apparently made because there were some issues with Firefox (#6) but in my local testing everything seems to work just fine with it now.

