### PR TITLE
port to rust-xcb 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT"
 travis-ci = { repository = "quininer/x11-clipboard" }
 
 [dependencies]
-xcb = { version = "0.10.1", features = [ "thread", "xfixes" ] }
+xcb = { version = "1.1.1", features = [ "xfixes" ] }


### PR DESCRIPTION
`rust-xcb-1.1.0` is not published yet, but here is how `x11-clipboard` would look like with it.
(It should be published in the coming days)

Alternatively, `rust-xcb-1.0.0` is published but will lack some of handy stuff I have used in this PR:
 - `hash` implementation of `Atom` (cannot use directly the `Atom` type as `HashMap` key)
 - [`atoms_struct` macro](https://rust-x-bindings.github.io/rust-xcb/xcb/macro.atoms_struct.html)
 - [`Connection::send_and_check_request`](https://rust-x-bindings.github.io/rust-xcb/xcb/struct.Connection.html#method.send_and_check_request) (this can be used everywhere you send a void request and then flush the connection).

fixes #25 