### PR TITLE
Reimplement using x11rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 Cargo.lock
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,5 @@ documentation = "https://docs.rs/x11-clipboard/"
 keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
 
-[badges]
-travis-ci = { repository = "quininer/x11-clipboard" }
-
 [dependencies]
-xcb = { version = "1.1.1", features = [ "xfixes" ] }
+x11rb = { version = "0.10.0", features = ["xfixes"]}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,22 @@
-use xcb::{ ConnError, ProtocolError };
-use xcb::x;
 use std::fmt;
 use std::sync::mpsc::SendError;
 use std::error::Error as StdError;
+use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
+use x11rb::protocol::xproto::Atom;
 
 #[must_use]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
-    Set(SendError<x::Atom>),
-    XcbConn(ConnError),
-    XcbProtocol(ProtocolError),
+    Set(SendError<Atom>),
+    XcbConnect(ConnectError),
+    XcbConnection(ConnectionError),
+    XcbReplyOrId(ReplyOrIdError),
+    XcbReply(ReplyError),
     Lock,
     Timeout,
     Owner,
-    UnexpectedType(x::Atom),
-
-    #[doc(hidden)]
-    __Unknown
+    UnexpectedType(Atom),
 }
 
 impl fmt::Display for Error {
@@ -24,13 +24,14 @@ impl fmt::Display for Error {
         use self::Error::*;
         match self {
             Set(e) => write!(f, "XCB - couldn't set atom: {:?}", e),
-            XcbConn(e) => write!(f, "XCB connection error: {:?}", e),
-            XcbProtocol(e) => write!(f, "XCB protocol error: {:?}", e),
+            XcbConnect(e) => write!(f, "XCB - couldn't establish conection: {:?}", e),
+            XcbConnection(e) => write!(f, "XCB connection error: {:?}", e),
+            XcbReplyOrId(e) => write!(f, "XCB reply error: {:?}", e),
+            XcbReply(e) => write!(f, "XCB reply error: {:?}", e),
             Lock => write!(f, "XCB: Lock is poisoned"),
             Timeout => write!(f, "Selection timed out"),
             Owner => write!(f, "Failed to set new owner of XCB selection"),
             UnexpectedType(target) => write!(f, "Unexpected Reply type: {:?}", target),
-            __Unknown => unreachable!()
         }
     }
 }
@@ -40,10 +41,11 @@ impl StdError for Error {
         use self::Error::*;
         match self {
             Set(e) => Some(e),
-            XcbConn(e) => Some(e),
-            XcbProtocol(e) => Some(e),
+            XcbConnection(e) => Some(e),
+            XcbReply(e) => Some(e),
+            XcbReplyOrId(e) => Some(e),
+            XcbConnect(e) => Some(e),
             Lock | Timeout | Owner | UnexpectedType(_) => None,
-            __Unknown => unreachable!()
         }
     }
 }
@@ -58,15 +60,8 @@ macro_rules! define_from {
     }
 }
 
-define_from!(Set from SendError<x::Atom>);
-define_from!(XcbConn from ConnError);
-define_from!(XcbProtocol from ProtocolError);
-
-impl From<xcb::Error> for Error {
-    fn from(err: xcb::Error) -> Error {
-        match err {
-            xcb::Error::Connection(err) => Error::XcbConn(err),
-            xcb::Error::Protocol(err) => Error::XcbProtocol(err),
-        }
-    }
-}
+define_from!(Set from SendError<Atom>);
+define_from!(XcbConnect from ConnectError);
+define_from!(XcbConnection from ConnectionError);
+define_from!(XcbReply from ReplyError);
+define_from!(XcbReplyOrId from ReplyOrIdError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ extern crate x11rb;
 pub mod error;
 mod run;
 
+pub use x11rb::protocol::xproto::{Atom, Window};
+pub use x11rb::rust_connection::RustConnection;
+
 use std::thread;
 use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
@@ -12,8 +15,7 @@ use x11rb::connection::{Connection, RequestConnection};
 use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
 use x11rb::errors::ConnectError;
 use x11rb::protocol::{Event, xfixes};
-use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, Window, WindowClass};
-use x11rb::rust_connection::RustConnection;
+use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass};
 use error::Error;
 
 pub const INCR_CHUNK_SIZE: usize = 4000;


### PR DESCRIPTION
I should have created an issue here first and got ahead of myself, I'm sorry about that. I saw this project as a transitive dependency, and having worked with different bindings to x11-libraries it looked like low-hanging fruit to implement this in pure rust over C-bindings which will always have risks of unsoundness issues. S I decided to try to implement this using x11rb which generates Rust-code to interface with x11 directly over the socket instead of doing that through a c-proxy-lib.

I've tested out the examples, tested using this as a dependency for [copypasta](https://crates.io/crates/copypasta) and it all works fine. This is a big change in code, it's a small lib and the change touches almost all of it, but it is no logical change, almost exclusively calling convention.

This becomes a breaking change for two reasons:

- Different Error cases:  
These are exposed publicly and sees some removes because the errors depended on structs from libxcb, I also converted the error to non_exhaustive, it was already non_exhaustive but done manually.
- Remove crate re-export:  
Previously xcb was publicly exposed, things contained as public fields for public structs are still re-exposed so that they can be named correctly in client code, but only those parts are re-exported now.

Hopefully you like the change, it at least ensures that there will be no unsoundness issues because of unsafe code in the primary library that this crate uses (although x11rb uses nix for some socket stuff so those aren't completely removed sadly).