### PR TITLE
make the clipboard sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 
 [dependencies]
 x11rb = { version = "0.10.0", features = ["xfixes"]}
+crossbeam-channel = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/quininer/x11-clipboard"
 documentation = "https://docs.rs/x11-clipboard/"
 keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
+edition = "2021"
 
 [dependencies]
 x11rb = { version = "0.10.0", features = ["xfixes"]}

--- a/examples/monitor_primary_selection.rs
+++ b/examples/monitor_primary_selection.rs
@@ -2,7 +2,6 @@ extern crate x11_clipboard;
 
 use x11_clipboard::Clipboard;
 
-
 fn main() {
     let clipboard = Clipboard::new().unwrap();
     let mut last = String::new();
@@ -13,12 +12,10 @@ fn main() {
         if let Ok(curr) = clipboard.load_wait(
             clipboard.getter.atoms.primary,
             clipboard.getter.atoms.utf8_string,
-            clipboard.getter.atoms.property
+            clipboard.getter.atoms.property,
         ) {
             let curr = String::from_utf8_lossy(&curr);
-            let curr = curr
-                .trim_matches('\u{0}')
-                .trim();
+            let curr = curr.trim_matches('\u{0}').trim();
             if !curr.is_empty() && last != curr {
                 last = curr.to_owned();
                 println!("Contents of primary selection: {}", last);

--- a/examples/paste.rs
+++ b/examples/paste.rs
@@ -1,17 +1,17 @@
 extern crate x11_clipboard;
 
 use std::time::Duration;
-use x11_clipboard::Clipboard;
 
+use x11_clipboard::Clipboard;
 
 fn main() {
     let clipboard = Clipboard::new().unwrap();
-    let val =
-        clipboard.load(
+    let val = clipboard
+        .load(
             clipboard.setter.atoms.clipboard,
             clipboard.setter.atoms.utf8_string,
             clipboard.setter.atoms.property,
-            Duration::from_secs(3)
+            Duration::from_secs(3),
         )
         .unwrap();
     let val = String::from_utf8(val).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use std::fmt;
 use std::error::Error as StdError;
+use std::fmt;
+
 use crossbeam_channel::SendError;
 use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::protocol::xproto::Atom;
@@ -57,7 +58,7 @@ macro_rules! define_from {
                 Error::$item(err)
             }
         }
-    }
+    };
 }
 
 define_from!(Set from SendError<Atom>);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
-use std::sync::mpsc::SendError;
 use std::error::Error as StdError;
+use crossbeam_channel::SendError;
 use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::protocol::xproto::Atom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate x11rb;
+extern crate crossbeam_channel;
 
 pub mod error;
 mod run;
@@ -9,8 +10,8 @@ pub use x11rb::rust_connection::RustConnection;
 use std::thread;
 use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
-use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
+use crossbeam_channel::Sender;
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
 use x11rb::errors::ConnectError;
@@ -138,7 +139,7 @@ impl Clipboard {
         let setmap = Arc::new(RwLock::new(HashMap::new()));
         let setmap2 = Arc::clone(&setmap);
 
-        let (sender, receiver) = channel();
+        let (sender, receiver) = crossbeam_channel::unbounded();
         let max_length = setter.connection.maximum_request_bytes();
         thread::spawn(move || run::run(&setter2, &setmap2, max_length, &receiver));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,27 @@
-extern crate x11rb;
-extern crate crossbeam_channel;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::Sender;
+use x11rb::connection::{Connection, RequestConnection};
+use x11rb::errors::ConnectError;
+pub use x11rb::protocol::xproto::{Atom, Window};
+use x11rb::protocol::xproto::{
+    AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass,
+};
+use x11rb::protocol::{xfixes, Event};
+pub use x11rb::rust_connection::RustConnection;
+use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
+
+use error::Error;
 
 pub mod error;
 mod run;
 
-pub use x11rb::protocol::xproto::{Atom, Window};
-pub use x11rb::rust_connection::RustConnection;
-
-use std::thread;
-use std::time::{ Duration, Instant };
-use std::sync::{ Arc, RwLock };
-use std::collections::HashMap;
-use crossbeam_channel::Sender;
-use x11rb::connection::{Connection, RequestConnection};
-use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
-use x11rb::errors::ConnectError;
-use x11rb::protocol::{Event, xfixes};
-use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass};
-use error::Error;
-
 pub const INCR_CHUNK_SIZE: usize = 4000;
 const POLL_DURATION: u64 = 50;
+
 type SetMap = Arc<RwLock<HashMap<Atom, (Atom, Vec<u8>)>>>;
 
 #[derive(Clone, Debug)]
@@ -36,26 +37,11 @@ pub struct Atoms {
 
 impl Atoms {
     fn intern_all(conn: &RustConnection) -> Result<Atoms, Error> {
-        let clipboard = conn.intern_atom(
-            false,
-            b"CLIPBOARD",
-        )?;
-        let property = conn.intern_atom(
-            false,
-            b"THIS_CLIPBOARD_OUT",
-        )?;
-        let targets = conn.intern_atom(
-            false,
-            b"TARGETS",
-        )?;
-        let utf8_string = conn.intern_atom(
-            false,
-            b"UTF8_STRING",
-        )?;
-        let incr = conn.intern_atom(
-            false,
-            b"INCR",
-        )?;
+        let clipboard = conn.intern_atom(false, b"CLIPBOARD")?;
+        let property = conn.intern_atom(false, b"THIS_CLIPBOARD_OUT")?;
+        let targets = conn.intern_atom(false, b"TARGETS")?;
+        let utf8_string = conn.intern_atom(false, b"UTF8_STRING")?;
+        let incr = conn.intern_atom(false, b"INCR")?;
         Ok(Atoms {
             primary: Atom::from(AtomEnum::PRIMARY),
             clipboard: clipboard.reply()?.atom,
@@ -73,24 +59,20 @@ pub struct Clipboard {
     pub getter: Context,
     pub setter: Arc<Context>,
     setmap: SetMap,
-    send: Sender<Atom>
+    send: Sender<Atom>,
 }
 
 pub struct Context {
     pub connection: RustConnection,
     pub screen: usize,
     pub window: Window,
-    pub atoms: Atoms
+    pub atoms: Atoms,
 }
 
 #[inline]
 fn get_atom(connection: &RustConnection, name: &str) -> Result<Atom, Error> {
-    let intern_atom = connection.intern_atom(
-        false,
-        name.as_bytes()
-    )?;
-    let reply = intern_atom.reply()
-        .map_err(Error::XcbReply)?;
+    let intern_atom = connection.intern_atom(false, name.as_bytes())?;
+    let reply = intern_atom.reply().map_err(Error::XcbReply)?;
     Ok(reply.atom)
 }
 
@@ -100,35 +82,43 @@ impl Context {
         let window = connection.generate_id()?;
 
         {
-            let screen = connection.setup().roots.get(screen)
+            let screen = connection
+                .setup()
+                .roots
+                .get(screen)
                 .ok_or(Error::XcbConnect(ConnectError::InvalidScreen))?;
-            connection.create_window(
-                COPY_DEPTH_FROM_PARENT,
-                window,
-                screen.root,
-                0,
-                0,
-                1,
-                1,
-                0,
-                WindowClass::INPUT_OUTPUT,
-                screen.root_visual,
-                &CreateWindowAux::new()
-                    .event_mask(EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE)
-            )?
+            connection
+                .create_window(
+                    COPY_DEPTH_FROM_PARENT,
+                    window,
+                    screen.root,
+                    0,
+                    0,
+                    1,
+                    1,
+                    0,
+                    WindowClass::INPUT_OUTPUT,
+                    screen.root_visual,
+                    &CreateWindowAux::new()
+                        .event_mask(EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE),
+                )?
                 .check()?;
         }
 
         let atoms = Atoms::intern_all(&connection)?;
 
-        Ok(Context { connection, screen, window, atoms })
+        Ok(Context {
+            connection,
+            screen,
+            window,
+            atoms,
+        })
     }
 
     pub fn get_atom(&self, name: &str) -> Result<Atom, Error> {
         get_atom(&self.connection, name)
     }
 }
-
 
 impl Clipboard {
     /// Create Clipboard.
@@ -143,21 +133,37 @@ impl Clipboard {
         let max_length = setter.connection.maximum_request_bytes();
         thread::spawn(move || run::run(&setter2, &setmap2, max_length, &receiver));
 
-        Ok(Clipboard { getter, setter, setmap, send: sender })
+        Ok(Clipboard {
+            getter,
+            setter,
+            setmap,
+            send: sender,
+        })
     }
 
-    fn process_event<T>(&self, buff: &mut Vec<u8>, selection: Atom, target: Atom, property: Atom, timeout: T, use_xfixes: bool)
-        -> Result<(), Error>
-        where T: Into<Option<Duration>>
+    fn process_event<T>(
+        &self,
+        buff: &mut Vec<u8>,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+        timeout: T,
+        use_xfixes: bool,
+    ) -> Result<(), Error>
+    where
+        T: Into<Option<Duration>>,
     {
         let mut is_incr = false;
         let timeout = timeout.into();
-        let start_time =
-            if timeout.is_some() { Some(Instant::now()) }
-            else { None };
+        let start_time = if timeout.is_some() {
+            Some(Instant::now())
+        } else {
+            None
+        };
 
         loop {
-            if timeout.into_iter()
+            if timeout
+                .into_iter()
                 .zip(start_time)
                 .next()
                 .map(|(timeout, time)| (Instant::now() - time) >= timeout)
@@ -168,29 +174,32 @@ impl Clipboard {
 
             let event = match use_xfixes {
                 true => self.getter.connection.wait_for_event()?,
-                false => {
-                    match self.getter.connection.poll_for_event()? {
-                        Some(event) => event,
-                        None => {
-                            thread::park_timeout(Duration::from_millis(POLL_DURATION));
-                            continue
-                        }
+                false => match self.getter.connection.poll_for_event()? {
+                    Some(event) => event,
+                    None => {
+                        thread::park_timeout(Duration::from_millis(POLL_DURATION));
+                        continue;
                     }
-                }
+                },
             };
 
             match event {
                 Event::XfixesSelectionNotify(event) if use_xfixes => {
-                    self.getter.connection.convert_selection(
-                        self.getter.window,
-                        selection,
-                        target,
-                        property,
-                        event.timestamp,
-                    )?.check()?;
+                    self.getter
+                        .connection
+                        .convert_selection(
+                            self.getter.window,
+                            selection,
+                            target,
+                            property,
+                            event.timestamp,
+                        )?
+                        .check()?;
                 }
                 Event::SelectionNotify(event) => {
-                    if event.selection != selection { continue };
+                    if event.selection != selection {
+                        continue;
+                    };
 
                     // Note that setting the property argument to None indicates that the
                     // conversion requested could not be made.
@@ -198,14 +207,18 @@ impl Clipboard {
                         break;
                     }
 
-                    let reply = self.getter.connection.get_property(
-                        false,
-                        self.getter.window,
-                        event.property,
-                        AtomEnum::NONE,
-                        buff.len() as u32,
-                        u32::MAX
-                    )?.reply()?;
+                    let reply = self
+                        .getter
+                        .connection
+                        .get_property(
+                            false,
+                            self.getter.window,
+                            event.property,
+                            AtomEnum::NONE,
+                            buff.len() as u32,
+                            u32::MAX,
+                        )?
+                        .reply()?;
 
                     if reply.type_ == self.getter.atoms.incr {
                         if let Some(mut value) = reply.value32() {
@@ -213,23 +226,24 @@ impl Clipboard {
                                 buff.reserve(size as usize);
                             }
                         }
-                        self.getter.connection.delete_property(
-                            self.getter.window,
-                            property
-                        )?.check()?;
+                        self.getter
+                            .connection
+                            .delete_property(self.getter.window, property)?
+                            .check()?;
                         is_incr = true;
-                        continue
+                        continue;
                     } else if reply.type_ != target {
                         return Err(Error::UnexpectedType(reply.type_));
                     }
 
                     buff.extend_from_slice(&reply.value);
-                    break
+                    break;
                 }
 
                 Event::PropertyNotify(event) if is_incr => {
-                    if event.state != Property::NEW_VALUE { continue };
-
+                    if event.state != Property::NEW_VALUE {
+                        continue;
+                    };
 
                     let cookie = self.getter.connection.get_property(
                         false,
@@ -237,7 +251,7 @@ impl Clipboard {
                         property,
                         AtomEnum::NONE,
                         0,
-                        0
+                        0,
                     )?;
 
                     let length = cookie.reply()?.bytes_after;
@@ -247,119 +261,144 @@ impl Clipboard {
                         self.getter.window,
                         property,
                         AtomEnum::NONE,
-                        0, length
+                        0,
+                        length,
                     )?;
                     let reply = cookie.reply()?;
-                    if reply.type_ != target { continue };
+                    if reply.type_ != target {
+                        continue;
+                    };
 
                     let value = reply.value;
 
                     if !value.is_empty() {
                         buff.extend_from_slice(&value);
                     } else {
-                        break
+                        break;
                     }
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         Ok(())
     }
 
     /// load value.
-    pub fn load<T>(&self, selection: Atom, target: Atom, property: Atom, timeout: T)
-        -> Result<Vec<u8>, Error>
-        where T: Into<Option<Duration>>
+    pub fn load<T>(
+        &self,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+        timeout: T,
+    ) -> Result<Vec<u8>, Error>
+    where
+        T: Into<Option<Duration>>,
     {
         let mut buff = Vec::new();
         let timeout = timeout.into();
 
-        self.getter.connection.convert_selection(
-            self.getter.window,
-            selection,
-            target,
-            property,
-            CURRENT_TIME,
-            // FIXME ^
-            // Clients should not use CurrentTime for the time argument of a ConvertSelection request.
-            // Instead, they should use the timestamp of the event that caused the request to be made.
-        )?.check()?;
+        self.getter
+            .connection
+            .convert_selection(
+                self.getter.window,
+                selection,
+                target,
+                property,
+                CURRENT_TIME,
+                // FIXME ^
+                // Clients should not use CurrentTime for the time argument of a ConvertSelection request.
+                // Instead, they should use the timestamp of the event that caused the request to be made.
+            )?
+            .check()?;
 
         self.process_event(&mut buff, selection, target, property, timeout, false)?;
 
-        self.getter.connection.delete_property(
-            self.getter.window,
-            property
-        )?.check()?;
+        self.getter
+            .connection
+            .delete_property(self.getter.window, property)?
+            .check()?;
 
         Ok(buff)
     }
 
     /// wait for a new value and load it
-    pub fn load_wait(&self, selection: Atom, target: Atom, property: Atom)
-        -> Result<Vec<u8>, Error>
-    {
+    pub fn load_wait(
+        &self,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+    ) -> Result<Vec<u8>, Error> {
         let mut buff = Vec::new();
 
-        let screen = &self.getter.connection.setup().roots.get(self.getter.screen)
+        let screen = &self
+            .getter
+            .connection
+            .setup()
+            .roots
+            .get(self.getter.screen)
             .ok_or(Error::XcbConnect(ConnectError::InvalidScreen))?;
 
-        xfixes::query_version(
-            &self.getter.connection,
-            5,
-            0,
-        )?;
+        xfixes::query_version(&self.getter.connection, 5, 0)?;
         // Clear selection sources...
         xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             self.getter.atoms.primary,
-            xfixes::SelectionEventMask::default()
+            xfixes::SelectionEventMask::default(),
         )?;
         xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             self.getter.atoms.clipboard,
-            xfixes::SelectionEventMask::default()
+            xfixes::SelectionEventMask::default(),
         )?;
         // ...and set the one requested now
         xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             selection,
-            xfixes::SelectionEventMask::SET_SELECTION_OWNER |
-                xfixes::SelectionEventMask::SELECTION_CLIENT_CLOSE |
-                xfixes::SelectionEventMask::SELECTION_WINDOW_DESTROY
-        )?.check()?;
+            xfixes::SelectionEventMask::SET_SELECTION_OWNER
+                | xfixes::SelectionEventMask::SELECTION_CLIENT_CLOSE
+                | xfixes::SelectionEventMask::SELECTION_WINDOW_DESTROY,
+        )?
+        .check()?;
 
         self.process_event(&mut buff, selection, target, property, None, true)?;
 
-        self.getter.connection.delete_property(self.getter.window, property)?.check()?;
+        self.getter
+            .connection
+            .delete_property(self.getter.window, property)?
+            .check()?;
 
         Ok(buff)
     }
 
     /// store value.
-    pub fn store<T: Into<Vec<u8>>>(&self, selection: Atom, target: Atom, value: T)
-        -> Result<(), Error>
-    {
+    pub fn store<T: Into<Vec<u8>>>(
+        &self,
+        selection: Atom,
+        target: Atom,
+        value: T,
+    ) -> Result<(), Error> {
         self.send.send(selection)?;
         self.setmap
             .write()
             .map_err(|_| Error::Lock)?
             .insert(selection, (target, value.into()));
 
-        self.setter.connection.set_selection_owner(
-            self.setter.window,
-            selection,
-            CURRENT_TIME
-        )?.check()?;
+        self.setter
+            .connection
+            .set_selection_owner(self.setter.window, selection, CURRENT_TIME)?
+            .check()?;
 
-        if self.setter.connection.get_selection_owner(
-            selection
-        )?.reply()
+        if self
+            .setter
+            .connection
+            .get_selection_owner(selection)?
+            .reply()
             .map(|reply| reply.owner == self.setter.window)
-            .unwrap_or(false) {
+            .unwrap_or(false)
+        {
             Ok(())
         } else {
             Err(Error::Owner)

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,18 +1,23 @@
 use std::cmp;
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
+
 use crossbeam_channel::{Receiver, TryRecvError};
-use ::{AtomEnum, EventMask};
 use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+    Atom, ChangeWindowAttributesAux, ConnectionExt, PropMode, Property, SelectionNotifyEvent,
+    Window, SELECTION_NOTIFY_EVENT,
+};
 use x11rb::protocol::Event;
-use x11rb::protocol::xproto::{Atom, ChangeWindowAttributesAux, ConnectionExt, Property, PropMode, SELECTION_NOTIFY_EVENT, SelectionNotifyEvent, Window};
-use ::{ INCR_CHUNK_SIZE, Context, SetMap };
+
+use crate::{AtomEnum, EventMask};
+use crate::{Context, SetMap, INCR_CHUNK_SIZE};
 
 macro_rules! try_continue {
     ( $expr:expr ) => {
         match $expr {
             Some(val) => val,
-            None => continue
+            None => continue,
         }
     };
 }
@@ -21,23 +26,26 @@ struct IncrState {
     selection: Atom,
     requestor: Window,
     property: Atom,
-    pos: usize
+    pos: usize,
 }
 
 pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver: &Receiver<Atom>) {
     let mut incr_map = HashMap::<Atom, Atom>::new();
     let mut state_map = HashMap::<Atom, IncrState>::new();
 
-
     while let Ok(event) = context.connection.wait_for_event() {
         loop {
             match receiver.try_recv() {
-                Ok(selection) => if let Some(property) = incr_map.remove(&selection) {
-                    state_map.remove(&property);
-                },
+                Ok(selection) => {
+                    if let Some(property) = incr_map.remove(&selection) {
+                        state_map.remove(&property);
+                    }
+                }
                 Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => if state_map.is_empty() {
-                    return
+                Err(TryRecvError::Disconnected) => {
+                    if state_map.is_empty() {
+                        return;
+                    }
                 }
             }
         }
@@ -54,7 +62,7 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                         event.requestor,
                         event.property,
                         Atom::from(AtomEnum::ATOM),
-                        &[context.atoms.targets, target]
+                        &[context.atoms.targets, target],
                     );
                 } else if value.len() < max_length - 24 {
                     let _ = x11rb::wrapper::ConnectionExt::change_property8(
@@ -63,13 +71,12 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                         event.requestor,
                         event.property,
                         target,
-                        value
+                        value,
                     );
                 } else {
                     let _ = context.connection.change_window_attributes(
                         event.requestor,
-                        &ChangeWindowAttributesAux::new()
-                            .event_mask(EventMask::PROPERTY_CHANGE)
+                        &ChangeWindowAttributesAux::new().event_mask(EventMask::PROPERTY_CHANGE),
                     );
                     let _ = x11rb::wrapper::ConnectionExt::change_property32(
                         &context.connection,
@@ -86,8 +93,8 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                             selection: event.selection,
                             requestor: event.requestor,
                             property: event.property,
-                            pos: 0
-                        }
+                            pos: 0,
+                        },
                     );
                 }
                 let _ = context.connection.send_event(
@@ -101,13 +108,15 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                         requestor: event.requestor,
                         selection: event.selection,
                         target,
-                        property: event.property
-                    }
+                        property: event.property,
+                    },
                 );
                 let _ = context.connection.flush();
-            },
+            }
             Event::PropertyNotify(event) => {
-                if event.state != Property::DELETE { continue };
+                if event.state != Property::DELETE {
+                    continue;
+                };
 
                 let is_end = {
                     let state = try_continue!(state_map.get_mut(&event.atom));
@@ -121,7 +130,7 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                         state.requestor,
                         state.property,
                         target,
-                        &value[state.pos..][..len]
+                        &value[state.pos..][..len],
                     );
                     state.pos += len;
                     len == 0
@@ -131,7 +140,7 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                     state_map.remove(&event.atom);
                 }
                 let _ = context.connection.flush();
-            },
+            }
             Event::SelectionClear(event) => {
                 if let Some(property) = incr_map.remove(&event.selection) {
                     state_map.remove(&property);
@@ -140,7 +149,7 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                     write_setmap.remove(&event.selection);
                 }
             }
-            _ => ()
+            _ => (),
         }
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 use std::sync::Arc;
-use std::sync::mpsc::{ Receiver, TryRecvError };
 use std::collections::HashMap;
+use crossbeam_channel::{Receiver, TryRecvError};
 use ::{AtomEnum, EventMask};
 use x11rb::connection::Connection;
 use x11rb::protocol::Event;

--- a/tests/simple-test.rs
+++ b/tests/simple-test.rs
@@ -1,8 +1,8 @@
 extern crate x11_clipboard;
 
-use std::time::{ Instant, Duration };
-use x11_clipboard::Clipboard;
+use std::time::{Duration, Instant};
 
+use x11_clipboard::Clipboard;
 
 #[test]
 fn it_work() {
@@ -13,21 +13,33 @@ fn it_work() {
     let atom_utf8string = clipboard.setter.atoms.utf8_string;
     let atom_property = clipboard.setter.atoms.property;
 
-    clipboard.store(atom_clipboard, atom_utf8string, data.as_bytes()).unwrap();
+    clipboard
+        .store(atom_clipboard, atom_utf8string, data.as_bytes())
+        .unwrap();
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
     let data = format!("{:?}", Instant::now());
-    clipboard.store(atom_clipboard, atom_utf8string, data.as_bytes()).unwrap();
+    clipboard
+        .store(atom_clipboard, atom_utf8string, data.as_bytes())
+        .unwrap();
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
     let dur = Duration::from_secs(3);
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, dur).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, dur)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 }


### PR DESCRIPTION
the `Clipboard` use std `Sender`, which is `!Sync`, that makes users can't put it into once_cell::sync::Lazy to create a static variable.

replace the std `Sender` with crossbeam-channel, can still use unbound Sender but make it sync