### PR TITLE
Fix selection notify on wrong target

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -100,7 +100,7 @@ pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver:
                         time: event.time,
                         requestor: event.requestor,
                         selection: event.selection,
-                        target,
+                        target: event.target,
                         property: event.property
                     }
                 );


### PR DESCRIPTION
Fixes https://github.com/quininer/x11-clipboard/issues/33.

On my previous change I accidentally made the selection notify specify the wrong target as the target to notify for the selection. 
This causes some applications to hang looping requests for the expected target. I'm surprised this didn't cause more issues, but by now I think a lot of x11 frameworks have a high tolerance for inter-client protocol mistakes and manage to recover.

I checked the fix against the example, pasting into brave, as well as built alacritty with the fix and it works there too. The mistake is pretty obvious when you see it, but not easy to spot in the changelist.

My bad, sorry about that!