### PR TITLE
Update x11rb dependency to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
 
 [dependencies]
-x11rb = { version = "0.10.0", features = ["xfixes"]}
+x11rb = { version = "0.12.0", features = ["xfixes"]}


### PR DESCRIPTION
As a sanity check, I ran through `cargo test` and checked that the examples still worked. Seems to work without additional changes.