### PR TITLE
Fix connection leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
 
 [dependencies]
-x11rb = { version = "0.12.0", features = ["xfixes"]}
+nix = { version = "0.27.1", features = ["poll", "event"] }
+x11rb = { version = "0.13.0", features = ["xfixes"]}

--- a/examples/monitor_primary_selection.rs
+++ b/examples/monitor_primary_selection.rs
@@ -2,7 +2,6 @@ extern crate x11_clipboard;
 
 use x11_clipboard::Clipboard;
 
-
 fn main() {
     let clipboard = Clipboard::new().unwrap();
     let mut last = String::new();
@@ -13,12 +12,10 @@ fn main() {
         if let Ok(curr) = clipboard.load_wait(
             clipboard.getter.atoms.primary,
             clipboard.getter.atoms.utf8_string,
-            clipboard.getter.atoms.property
+            clipboard.getter.atoms.property,
         ) {
             let curr = String::from_utf8_lossy(&curr);
-            let curr = curr
-                .trim_matches('\u{0}')
-                .trim();
+            let curr = curr.trim_matches('\u{0}').trim();
             if !curr.is_empty() && last != curr {
                 last = curr.to_owned();
                 println!("Contents of primary selection: {}", last);

--- a/examples/paste.rs
+++ b/examples/paste.rs
@@ -3,15 +3,14 @@ extern crate x11_clipboard;
 use std::time::Duration;
 use x11_clipboard::Clipboard;
 
-
 fn main() {
     let clipboard = Clipboard::new().unwrap();
-    let val =
-        clipboard.load(
+    let val = clipboard
+        .load(
             clipboard.setter.atoms.clipboard,
             clipboard.setter.atoms.utf8_string,
             clipboard.setter.atoms.property,
-            Duration::from_secs(3)
+            Duration::from_secs(3),
         )
         .unwrap();
     let val = String::from_utf8(val).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
+use nix::errno::Errno;
+use std::error::Error as StdError;
 use std::fmt;
 use std::sync::mpsc::SendError;
-use std::error::Error as StdError;
-use nix::errno::Errno;
 use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::protocol::xproto::Atom;
 
@@ -60,7 +60,7 @@ macro_rules! define_from {
                 Error::$item(err)
             }
         }
-    }
+    };
 }
 
 define_from!(Set from SendError<Atom>);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::sync::mpsc::SendError;
 use std::error::Error as StdError;
+use nix::errno::Errno;
 use x11rb::errors::{ConnectError, ConnectionError, ReplyError, ReplyOrIdError};
 use x11rb::protocol::xproto::Atom;
 
@@ -17,6 +18,7 @@ pub enum Error {
     Timeout,
     Owner,
     UnexpectedType(Atom),
+    EventFdCreate(Errno),
 }
 
 impl fmt::Display for Error {
@@ -32,6 +34,7 @@ impl fmt::Display for Error {
             Timeout => write!(f, "Selection timed out"),
             Owner => write!(f, "Failed to set new owner of XCB selection"),
             UnexpectedType(target) => write!(f, "Unexpected Reply type: {:?}", target),
+            EventFdCreate(e) => write!(f, "Failed to create eventfd, errno={e}"),
         }
     }
 }
@@ -45,7 +48,7 @@ impl StdError for Error {
             XcbReply(e) => Some(e),
             XcbReplyOrId(e) => Some(e),
             XcbConnect(e) => Some(e),
-            Lock | Timeout | Owner | UnexpectedType(_) => None,
+            Lock | Timeout | Owner | UnexpectedType(_) | EventFdCreate(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate x11rb;
+extern crate nix;
 
 pub mod error;
 mod run;
@@ -11,12 +12,14 @@ use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
 use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
+use std::os::fd::AsRawFd;
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
 use x11rb::errors::ConnectError;
 use x11rb::protocol::{Event, xfixes};
 use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass};
 use error::Error;
+use run::{create_eventfd, EventFd};
 
 pub const INCR_CHUNK_SIZE: usize = 4000;
 const POLL_DURATION: u64 = 50;
@@ -72,9 +75,18 @@ pub struct Clipboard {
     pub getter: Context,
     pub setter: Arc<Context>,
     setmap: SetMap,
-    send: Sender<Atom>
+    send: Sender<Atom>,
+    efd: EventFd,
 }
 
+impl Drop for Clipboard {
+    fn drop(&mut self) {
+        // Need to write any 8 bytes that are not 0 to trigger a read-ready
+        const ANY: &[u8; 8] = &[1, 1, 1, 1, 1, 1, 1, 1];
+        // Best attempt close stream on thread
+        let _ = nix::unistd::write(self.efd.0.as_raw_fd(), ANY);
+    }
+}
 pub struct Context {
     pub connection: RustConnection,
     pub screen: usize,
@@ -138,11 +150,13 @@ impl Clipboard {
         let setmap = Arc::new(RwLock::new(HashMap::new()));
         let setmap2 = Arc::clone(&setmap);
 
+        let efd = create_eventfd()?;
+        let efd_c = efd.clone();
         let (sender, receiver) = channel();
         let max_length = setter.connection.maximum_request_bytes();
-        thread::spawn(move || run::run(&setter2, &setmap2, max_length, &receiver));
+        thread::spawn(move || run::run(setter2, setmap2, max_length, receiver, efd_c));
 
-        Ok(Clipboard { getter, setter, setmap, send: sender })
+        Ok(Clipboard { getter, setter, setmap, send: sender, efd })
     }
 
     fn process_event<T>(&self, buff: &mut Vec<u8>, selection: Atom, target: Atom, property: Atom, timeout: T, use_xfixes: bool, sequence_number: u64)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-extern crate x11rb;
 extern crate nix;
+extern crate x11rb;
 
 pub mod error;
 mod run;
@@ -7,19 +7,21 @@ mod run;
 pub use x11rb::protocol::xproto::{Atom, Window};
 pub use x11rb::rust_connection::RustConnection;
 
-use std::thread;
-use std::time::{ Duration, Instant };
-use std::sync::{ Arc, RwLock };
-use std::sync::mpsc::{ Sender, channel };
-use std::collections::HashMap;
-use std::os::fd::AsRawFd;
-use x11rb::connection::{Connection, RequestConnection};
-use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
-use x11rb::errors::ConnectError;
-use x11rb::protocol::{Event, xfixes};
-use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass};
 use error::Error;
 use run::{create_eventfd, EventFd};
+use std::collections::HashMap;
+use std::os::fd::AsRawFd;
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+use x11rb::connection::{Connection, RequestConnection};
+use x11rb::errors::ConnectError;
+use x11rb::protocol::xproto::{
+    AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass,
+};
+use x11rb::protocol::{xfixes, Event};
+use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
 
 pub const INCR_CHUNK_SIZE: usize = 4000;
 const POLL_DURATION: u64 = 50;
@@ -38,26 +40,11 @@ pub struct Atoms {
 
 impl Atoms {
     fn intern_all(conn: &RustConnection) -> Result<Atoms, Error> {
-        let clipboard = conn.intern_atom(
-            false,
-            b"CLIPBOARD",
-        )?;
-        let property = conn.intern_atom(
-            false,
-            b"THIS_CLIPBOARD_OUT",
-        )?;
-        let targets = conn.intern_atom(
-            false,
-            b"TARGETS",
-        )?;
-        let utf8_string = conn.intern_atom(
-            false,
-            b"UTF8_STRING",
-        )?;
-        let incr = conn.intern_atom(
-            false,
-            b"INCR",
-        )?;
+        let clipboard = conn.intern_atom(false, b"CLIPBOARD")?;
+        let property = conn.intern_atom(false, b"THIS_CLIPBOARD_OUT")?;
+        let targets = conn.intern_atom(false, b"TARGETS")?;
+        let utf8_string = conn.intern_atom(false, b"UTF8_STRING")?;
+        let incr = conn.intern_atom(false, b"INCR")?;
         Ok(Atoms {
             primary: Atom::from(AtomEnum::PRIMARY),
             clipboard: clipboard.reply()?.atom,
@@ -91,17 +78,13 @@ pub struct Context {
     pub connection: RustConnection,
     pub screen: usize,
     pub window: Window,
-    pub atoms: Atoms
+    pub atoms: Atoms,
 }
 
 #[inline]
 fn get_atom(connection: &RustConnection, name: &str) -> Result<Atom, Error> {
-    let intern_atom = connection.intern_atom(
-        false,
-        name.as_bytes()
-    )?;
-    let reply = intern_atom.reply()
-        .map_err(Error::XcbReply)?;
+    let intern_atom = connection.intern_atom(false, name.as_bytes())?;
+    let reply = intern_atom.reply().map_err(Error::XcbReply)?;
     Ok(reply.atom)
 }
 
@@ -111,35 +94,43 @@ impl Context {
         let window = connection.generate_id()?;
 
         {
-            let screen = connection.setup().roots.get(screen)
+            let screen = connection
+                .setup()
+                .roots
+                .get(screen)
                 .ok_or(Error::XcbConnect(ConnectError::InvalidScreen))?;
-            connection.create_window(
-                COPY_DEPTH_FROM_PARENT,
-                window,
-                screen.root,
-                0,
-                0,
-                1,
-                1,
-                0,
-                WindowClass::INPUT_OUTPUT,
-                screen.root_visual,
-                &CreateWindowAux::new()
-                    .event_mask(EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE)
-            )?
+            connection
+                .create_window(
+                    COPY_DEPTH_FROM_PARENT,
+                    window,
+                    screen.root,
+                    0,
+                    0,
+                    1,
+                    1,
+                    0,
+                    WindowClass::INPUT_OUTPUT,
+                    screen.root_visual,
+                    &CreateWindowAux::new()
+                        .event_mask(EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE),
+                )?
                 .check()?;
         }
 
         let atoms = Atoms::intern_all(&connection)?;
 
-        Ok(Context { connection, screen, window, atoms })
+        Ok(Context {
+            connection,
+            screen,
+            window,
+            atoms,
+        })
     }
 
     pub fn get_atom(&self, name: &str) -> Result<Atom, Error> {
         get_atom(&self.connection, name)
     }
 }
-
 
 impl Clipboard {
     /// Create Clipboard.
@@ -156,21 +147,40 @@ impl Clipboard {
         let max_length = setter.connection.maximum_request_bytes();
         thread::spawn(move || run::run(setter2, setmap2, max_length, receiver, efd_c));
 
-        Ok(Clipboard { getter, setter, setmap, send: sender, efd })
+        Ok(Clipboard {
+            getter,
+            setter,
+            setmap,
+            send: sender,
+            efd,
+        })
     }
 
-    fn process_event<T>(&self, buff: &mut Vec<u8>, selection: Atom, target: Atom, property: Atom, timeout: T, use_xfixes: bool, sequence_number: u64)
-        -> Result<(), Error>
-        where T: Into<Option<Duration>>
+    #[allow(clippy::too_many_arguments)]
+    fn process_event<T>(
+        &self,
+        buff: &mut Vec<u8>,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+        timeout: T,
+        use_xfixes: bool,
+        sequence_number: u64,
+    ) -> Result<(), Error>
+    where
+        T: Into<Option<Duration>>,
     {
         let mut is_incr = false;
         let timeout = timeout.into();
-        let start_time =
-            if timeout.is_some() { Some(Instant::now()) }
-            else { None };
+        let start_time = if timeout.is_some() {
+            Some(Instant::now())
+        } else {
+            None
+        };
 
         loop {
-            if timeout.into_iter()
+            if timeout
+                .into_iter()
                 .zip(start_time)
                 .next()
                 .map(|(timeout, time)| (Instant::now() - time) >= timeout)
@@ -181,15 +191,13 @@ impl Clipboard {
 
             let (event, seq) = match use_xfixes {
                 true => self.getter.connection.wait_for_event_with_sequence()?,
-                false => {
-                    match self.getter.connection.poll_for_event_with_sequence()? {
-                        Some(event) => event,
-                        None => {
-                            thread::park_timeout(Duration::from_millis(POLL_DURATION));
-                            continue
-                        }
+                false => match self.getter.connection.poll_for_event_with_sequence()? {
+                    Some(event) => event,
+                    None => {
+                        thread::park_timeout(Duration::from_millis(POLL_DURATION));
+                        continue;
                     }
-                }
+                },
             };
 
             if seq < sequence_number {
@@ -198,16 +206,21 @@ impl Clipboard {
 
             match event {
                 Event::XfixesSelectionNotify(event) if use_xfixes => {
-                    self.getter.connection.convert_selection(
-                        self.getter.window,
-                        selection,
-                        target,
-                        property,
-                        event.timestamp,
-                    )?.check()?;
+                    self.getter
+                        .connection
+                        .convert_selection(
+                            self.getter.window,
+                            selection,
+                            target,
+                            property,
+                            event.timestamp,
+                        )?
+                        .check()?;
                 }
                 Event::SelectionNotify(event) => {
-                    if event.selection != selection { continue };
+                    if event.selection != selection {
+                        continue;
+                    };
 
                     // Note that setting the property argument to None indicates that the
                     // conversion requested could not be made.
@@ -215,14 +228,18 @@ impl Clipboard {
                         break;
                     }
 
-                    let reply = self.getter.connection.get_property(
-                        false,
-                        self.getter.window,
-                        event.property,
-                        AtomEnum::NONE,
-                        buff.len() as u32,
-                        u32::MAX
-                    )?.reply()?;
+                    let reply = self
+                        .getter
+                        .connection
+                        .get_property(
+                            false,
+                            self.getter.window,
+                            event.property,
+                            AtomEnum::NONE,
+                            buff.len() as u32,
+                            u32::MAX,
+                        )?
+                        .reply()?;
 
                     if reply.type_ == self.getter.atoms.incr {
                         if let Some(mut value) = reply.value32() {
@@ -230,23 +247,24 @@ impl Clipboard {
                                 buff.reserve(size as usize);
                             }
                         }
-                        self.getter.connection.delete_property(
-                            self.getter.window,
-                            property
-                        )?.check()?;
+                        self.getter
+                            .connection
+                            .delete_property(self.getter.window, property)?
+                            .check()?;
                         is_incr = true;
-                        continue
+                        continue;
                     } else if reply.type_ != target {
                         return Err(Error::UnexpectedType(reply.type_));
                     }
 
                     buff.extend_from_slice(&reply.value);
-                    break
+                    break;
                 }
 
                 Event::PropertyNotify(event) if is_incr => {
-                    if event.state != Property::NEW_VALUE { continue };
-
+                    if event.state != Property::NEW_VALUE {
+                        continue;
+                    };
 
                     let cookie = self.getter.connection.get_property(
                         false,
@@ -254,7 +272,7 @@ impl Clipboard {
                         property,
                         AtomEnum::NONE,
                         0,
-                        0
+                        0,
                     )?;
 
                     let length = cookie.reply()?.bytes_after;
@@ -264,29 +282,38 @@ impl Clipboard {
                         self.getter.window,
                         property,
                         AtomEnum::NONE,
-                        0, length
+                        0,
+                        length,
                     )?;
                     let reply = cookie.reply()?;
-                    if reply.type_ != target { continue };
+                    if reply.type_ != target {
+                        continue;
+                    };
 
                     let value = reply.value;
 
                     if !value.is_empty() {
                         buff.extend_from_slice(&value);
                     } else {
-                        break
+                        break;
                     }
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         Ok(())
     }
 
     /// load value.
-    pub fn load<T>(&self, selection: Atom, target: Atom, property: Atom, timeout: T)
-        -> Result<Vec<u8>, Error>
-        where T: Into<Option<Duration>>
+    pub fn load<T>(
+        &self,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+        timeout: T,
+    ) -> Result<Vec<u8>, Error>
+    where
+        T: Into<Option<Duration>>,
     {
         let mut buff = Vec::new();
         let timeout = timeout.into();
@@ -305,84 +332,112 @@ impl Clipboard {
         let sequence_number = cookie.sequence_number();
         cookie.check()?;
 
-        self.process_event(&mut buff, selection, target, property, timeout, false, sequence_number)?;
+        self.process_event(
+            &mut buff,
+            selection,
+            target,
+            property,
+            timeout,
+            false,
+            sequence_number,
+        )?;
 
-        self.getter.connection.delete_property(
-            self.getter.window,
-            property
-        )?.check()?;
+        self.getter
+            .connection
+            .delete_property(self.getter.window, property)?
+            .check()?;
 
         Ok(buff)
     }
 
     /// wait for a new value and load it
-    pub fn load_wait(&self, selection: Atom, target: Atom, property: Atom)
-        -> Result<Vec<u8>, Error>
-    {
+    pub fn load_wait(
+        &self,
+        selection: Atom,
+        target: Atom,
+        property: Atom,
+    ) -> Result<Vec<u8>, Error> {
         let mut buff = Vec::new();
 
-        let screen = &self.getter.connection.setup().roots.get(self.getter.screen)
+        let screen = &self
+            .getter
+            .connection
+            .setup()
+            .roots
+            .get(self.getter.screen)
             .ok_or(Error::XcbConnect(ConnectError::InvalidScreen))?;
 
-        xfixes::query_version(
-            &self.getter.connection,
-            5,
-            0,
-        )?;
+        xfixes::query_version(&self.getter.connection, 5, 0)?;
         // Clear selection sources...
         xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             self.getter.atoms.primary,
-            xfixes::SelectionEventMask::default()
+            xfixes::SelectionEventMask::default(),
         )?;
         xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             self.getter.atoms.clipboard,
-            xfixes::SelectionEventMask::default()
+            xfixes::SelectionEventMask::default(),
         )?;
         // ...and set the one requested now
         let cookie = xfixes::select_selection_input(
             &self.getter.connection,
             screen.root,
             selection,
-            xfixes::SelectionEventMask::SET_SELECTION_OWNER |
-                xfixes::SelectionEventMask::SELECTION_CLIENT_CLOSE |
-                xfixes::SelectionEventMask::SELECTION_WINDOW_DESTROY
+            xfixes::SelectionEventMask::SET_SELECTION_OWNER
+                | xfixes::SelectionEventMask::SELECTION_CLIENT_CLOSE
+                | xfixes::SelectionEventMask::SELECTION_WINDOW_DESTROY,
         )?;
 
         let sequence_number = cookie.sequence_number();
         cookie.check()?;
 
-        self.process_event(&mut buff, selection, target, property, None, true, sequence_number)?;
+        self.process_event(
+            &mut buff,
+            selection,
+            target,
+            property,
+            None,
+            true,
+            sequence_number,
+        )?;
 
-        self.getter.connection.delete_property(self.getter.window, property)?.check()?;
+        self.getter
+            .connection
+            .delete_property(self.getter.window, property)?
+            .check()?;
 
         Ok(buff)
     }
 
     /// store value.
-    pub fn store<T: Into<Vec<u8>>>(&self, selection: Atom, target: Atom, value: T)
-        -> Result<(), Error>
-    {
+    pub fn store<T: Into<Vec<u8>>>(
+        &self,
+        selection: Atom,
+        target: Atom,
+        value: T,
+    ) -> Result<(), Error> {
         self.send.send(selection)?;
         self.setmap
             .write()
             .map_err(|_| Error::Lock)?
             .insert(selection, (target, value.into()));
 
-        self.setter.connection.set_selection_owner(
-            self.setter.window,
-            selection,
-            CURRENT_TIME
-        )?.check()?;
+        self.setter
+            .connection
+            .set_selection_owner(self.setter.window, selection, CURRENT_TIME)?
+            .check()?;
 
-        if self.setter.connection.get_selection_owner(
-            selection
-        )?.reply()
+        if self
+            .setter
+            .connection
+            .get_selection_owner(selection)?
+            .reply()
             .map(|reply| reply.owner == self.setter.window)
-            .unwrap_or(false) {
+            .unwrap_or(false)
+        {
             Ok(())
         } else {
             Err(Error::Owner)

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,11 +2,15 @@ use std::cmp;
 use std::sync::Arc;
 use std::sync::mpsc::{ Receiver, TryRecvError };
 use std::collections::HashMap;
+use std::os::fd::{AsFd, OwnedFd};
+use nix::poll::{PollFd, PollFlags};
+use nix::sys::eventfd::EfdFlags;
 use ::{AtomEnum, EventMask};
 use x11rb::connection::Connection;
 use x11rb::protocol::Event;
 use x11rb::protocol::xproto::{Atom, ChangeWindowAttributesAux, ConnectionExt, Property, PropMode, SELECTION_NOTIFY_EVENT, SelectionNotifyEvent, Window};
 use ::{ INCR_CHUNK_SIZE, Context, SetMap };
+use error::Error;
 
 macro_rules! try_continue {
     ( $expr:expr ) => {
@@ -24,123 +28,151 @@ struct IncrState {
     pos: usize
 }
 
-pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver: &Receiver<Atom>) {
+
+#[derive(Clone)]
+pub(crate) struct EventFd(pub(crate) Arc<OwnedFd>);
+
+pub(crate) fn create_eventfd() -> Result<EventFd, Error>{
+    let raw = nix::sys::eventfd::eventfd(0, EfdFlags::EFD_CLOEXEC)
+        .map_err(Error::EventFdCreate)?;
+    Ok(EventFd(Arc::new(raw)))
+}
+
+pub fn run(context: Arc<Context>, setmap: SetMap, max_length: usize, receiver: Receiver<Atom>, evt_fd: EventFd) {
     let mut incr_map = HashMap::<Atom, Atom>::new();
     let mut state_map = HashMap::<Atom, IncrState>::new();
 
-
-    while let Ok(event) = context.connection.wait_for_event() {
+    let stream_fd = context.connection.stream().as_fd();
+    let borrowed_fd = evt_fd.0.as_fd();
+    // Poll both stream and eventfd for new Read-ready events
+    let mut poll_fds = [PollFd::new(&stream_fd, PollFlags::POLLIN), PollFd::new(&borrowed_fd, PollFlags::POLLIN)];
+    while nix::poll::poll(&mut poll_fds, -1).is_ok() {
+        if let Some(PollFlags::POLLIN) = poll_fds[1].revents() {
+            // kill-signal
+            return;
+        }
         loop {
-            match receiver.try_recv() {
-                Ok(selection) => if let Some(property) = incr_map.remove(&selection) {
-                    state_map.remove(&property);
-                },
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => if state_map.is_empty() {
-                    return
+            let Ok(evt) = context.connection.poll_for_event() else {
+                // Exit on error
+                return;
+            };
+            let Some(event) = evt else {
+                // No event on POLLIN happens, fd being readable doesn't mean theres a complete event ready to read.
+                // Poll again.
+                break;
+            };
+            loop {
+                match receiver.try_recv() {
+                    Ok(selection) => if let Some(property) = incr_map.remove(&selection) {
+                        state_map.remove(&property);
+                    },
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => if state_map.is_empty() {
+                        return
+                    }
                 }
             }
-        }
 
-        match event {
-            Event::SelectionRequest(event) => {
-                let read_map = try_continue!(setmap.read().ok());
-                let &(target, ref value) = try_continue!(read_map.get(&event.selection));
+            match event {
+                Event::SelectionRequest(event) => {
+                    let read_map = try_continue!(setmap.read().ok());
+                    let &(target, ref value) = try_continue!(read_map.get(&event.selection));
 
-                if event.target == context.atoms.targets {
-                    let _ = x11rb::wrapper::ConnectionExt::change_property32(
-                        &context.connection,
-                        PropMode::REPLACE,
+                    if event.target == context.atoms.targets {
+                        let _ = x11rb::wrapper::ConnectionExt::change_property32(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            Atom::from(AtomEnum::ATOM),
+                            &[context.atoms.targets, target]
+                        );
+                    } else if value.len() < max_length - 24 {
+                        let _ = x11rb::wrapper::ConnectionExt::change_property8(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            target,
+                            value
+                        );
+                    } else {
+                        let _ = context.connection.change_window_attributes(
+                            event.requestor,
+                            &ChangeWindowAttributesAux::new()
+                                .event_mask(EventMask::PROPERTY_CHANGE)
+                        );
+                        let _ = x11rb::wrapper::ConnectionExt::change_property32(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            context.atoms.incr,
+                            &[0u32; 0],
+                        );
+                        incr_map.insert(event.selection, event.property);
+                        state_map.insert(
+                            event.property,
+                            IncrState {
+                                selection: event.selection,
+                                requestor: event.requestor,
+                                property: event.property,
+                                pos: 0
+                            }
+                        );
+                    }
+                    let _ = context.connection.send_event(
+                        false,
                         event.requestor,
-                        event.property,
-                        Atom::from(AtomEnum::ATOM),
-                        &[context.atoms.targets, target]
-                    );
-                } else if value.len() < max_length - 24 {
-                    let _ = x11rb::wrapper::ConnectionExt::change_property8(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        event.requestor,
-                        event.property,
-                        target,
-                        value
-                    );
-                } else {
-                    let _ = context.connection.change_window_attributes(
-                        event.requestor,
-                        &ChangeWindowAttributesAux::new()
-                            .event_mask(EventMask::PROPERTY_CHANGE)
-                    );
-                    let _ = x11rb::wrapper::ConnectionExt::change_property32(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        event.requestor,
-                        event.property,
-                        context.atoms.incr,
-                        &[0u32; 0],
-                    );
-                    incr_map.insert(event.selection, event.property);
-                    state_map.insert(
-                        event.property,
-                        IncrState {
-                            selection: event.selection,
+                        EventMask::default(),
+                        SelectionNotifyEvent {
+                            response_type: SELECTION_NOTIFY_EVENT,
+                            sequence: 0,
+                            time: event.time,
                             requestor: event.requestor,
-                            property: event.property,
-                            pos: 0
+                            selection: event.selection,
+                            target: event.target,
+                            property: event.property
                         }
                     );
-                }
-                let _ = context.connection.send_event(
-                    false,
-                    event.requestor,
-                    EventMask::default(),
-                    SelectionNotifyEvent {
-                        response_type: SELECTION_NOTIFY_EVENT,
-                        sequence: 0,
-                        time: event.time,
-                        requestor: event.requestor,
-                        selection: event.selection,
-                        target: event.target,
-                        property: event.property
+                    let _ = context.connection.flush();
+                },
+                Event::PropertyNotify(event) => {
+                    if event.state != Property::DELETE { continue };
+
+                    let is_end = {
+                        let state = try_continue!(state_map.get_mut(&event.atom));
+                        let read_setmap = try_continue!(setmap.read().ok());
+                        let &(target, ref value) = try_continue!(read_setmap.get(&state.selection));
+
+                        let len = cmp::min(INCR_CHUNK_SIZE, value.len() - state.pos);
+                        let _ = x11rb::wrapper::ConnectionExt::change_property8(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            state.requestor,
+                            state.property,
+                            target,
+                            &value[state.pos..][..len]
+                        );
+                        state.pos += len;
+                        len == 0
+                    };
+
+                    if is_end {
+                        state_map.remove(&event.atom);
                     }
-                );
-                let _ = context.connection.flush();
-            },
-            Event::PropertyNotify(event) => {
-                if event.state != Property::DELETE { continue };
-
-                let is_end = {
-                    let state = try_continue!(state_map.get_mut(&event.atom));
-                    let read_setmap = try_continue!(setmap.read().ok());
-                    let &(target, ref value) = try_continue!(read_setmap.get(&state.selection));
-
-                    let len = cmp::min(INCR_CHUNK_SIZE, value.len() - state.pos);
-                    let _ = x11rb::wrapper::ConnectionExt::change_property8(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        state.requestor,
-                        state.property,
-                        target,
-                        &value[state.pos..][..len]
-                    );
-                    state.pos += len;
-                    len == 0
-                };
-
-                if is_end {
-                    state_map.remove(&event.atom);
+                    let _ = context.connection.flush();
+                },
+                Event::SelectionClear(event) => {
+                    if let Some(property) = incr_map.remove(&event.selection) {
+                        state_map.remove(&property);
+                    }
+                    if let Ok(mut write_setmap) = setmap.write() {
+                        write_setmap.remove(&event.selection);
+                    }
                 }
-                let _ = context.connection.flush();
-            },
-            Event::SelectionClear(event) => {
-                if let Some(property) = incr_map.remove(&event.selection) {
-                    state_map.remove(&property);
-                }
-                if let Ok(mut write_setmap) = setmap.write() {
-                    write_setmap.remove(&event.selection);
-                }
+                _ => ()
             }
-            _ => ()
         }
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -62,11 +62,15 @@ pub fn run(
             return;
         }
         loop {
-            let Ok(evt) = context.connection.poll_for_event() else {
+            let evt = if let Ok(evt) = context.connection.poll_for_event() {
+                evt
+            } else {
                 // Exit on error
                 return;
             };
-            let Some(event) = evt else {
+            let event = if let Some(event) = evt {
+                event
+            } else {
                 // No event on POLLIN happens, fd being readable doesn't mean theres a complete event ready to read.
                 // Poll again.
                 break;

--- a/tests/simple-test.rs
+++ b/tests/simple-test.rs
@@ -1,8 +1,7 @@
 extern crate x11_clipboard;
 
-use std::time::{ Instant, Duration };
+use std::time::{Duration, Instant};
 use x11_clipboard::Clipboard;
-
 
 #[test]
 fn it_work() {
@@ -13,21 +12,33 @@ fn it_work() {
     let atom_utf8string = clipboard.setter.atoms.utf8_string;
     let atom_property = clipboard.setter.atoms.property;
 
-    clipboard.store(atom_clipboard, atom_utf8string, data.as_bytes()).unwrap();
+    clipboard
+        .store(atom_clipboard, atom_utf8string, data.as_bytes())
+        .unwrap();
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
     let data = format!("{:?}", Instant::now());
-    clipboard.store(atom_clipboard, atom_utf8string, data.as_bytes()).unwrap();
+    clipboard
+        .store(atom_clipboard, atom_utf8string, data.as_bytes())
+        .unwrap();
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, None).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, None)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 
     let dur = Duration::from_secs(3);
-    let output = clipboard.load(atom_clipboard, atom_utf8string, atom_property, dur).unwrap();
+    let output = clipboard
+        .load(atom_clipboard, atom_utf8string, atom_property, dur)
+        .unwrap();
     assert_eq!(output, data.as_bytes());
 }


### PR DESCRIPTION
Related to https://github.com/pot-app/Selection/issues/3.

# Problem

As was found in the linked issue, the library leaks connections. 

The reason for it is that the thread that's spawned to listen to events blocks for the next event.

# Solution

There are probably more graceful ways to handle this, but it's kind of tricky. Since the thread is blocking waiting for input from the stream, which comes when the stream is ready, it's possible to poll it with a POLLIN, and then use the non-blocking method to try to retrieve the next event. 

Again, it's sync-blocking hanging on the os signaling POLLIN, the easiest way that I could figure was to use an eventfd and poll that for POLLIN as well.

So instead of blocking for the next event, it blocks on a POLL for the EventFd and the underlying x11-fd, when one is ready, it checks if the EventFd was the one that fired, if so it exits, if not it tries to pop the next event from x11 and continues.

It is kind-of-possible to close the stream's FD on clipboard drop, but it's both a bit dicey and unreliable, although that would net the least amount of changed code. Although the actual diff is about 50 lines, an indentation-change increased it by a `~ +=100` when messing with the thread loop.

See the first commit 2252ec66e1e3c59c3786dc93b70cf72a0ddaf255 for the actual diff, the second is formatting, the third reverts some let-else use that this project might not support.

# Testing

Ran the tests on the project, I also used xrestop using [this project's](https://github.com/pot-app/Selection/issues/3) get_text-implementation in a forever-loop, this definitely fixes the leak that the reporter saw.

# Drive-by

Updates x11rb, pulls in nix (which is pulled in transitively anyway) to do the polling/eventing.