### PR TITLE
Update x11rb to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
 
 [dependencies]
-x11rb = { version = "0.12.0", features = ["xfixes"]}
+x11rb = { version = "0.13.0", features = ["xfixes"]}


### PR DESCRIPTION
A release with this update would help us avoid multiple versions of x11rb in our builds, while Winit 0.29 depends on x11rb 0.13

I've run `cargo test` and each of the examples and everything seems to be working with the update.

Fixes: #41
