### PR TITLE
Fix connection leak using libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ keywords = [ "x11", "xcb", "clipboard" ]
 license = "MIT"
 
 [dependencies]
+libc = { version = "0.2.152" }
 x11rb = { version = "0.13.0", features = ["xfixes"]}

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     Timeout,
     Owner,
     UnexpectedType(Atom),
+    EventFdCreate,
 }
 
 impl fmt::Display for Error {
@@ -32,6 +33,7 @@ impl fmt::Display for Error {
             Timeout => write!(f, "Selection timed out"),
             Owner => write!(f, "Failed to set new owner of XCB selection"),
             UnexpectedType(target) => write!(f, "Unexpected Reply type: {:?}", target),
+            EventFdCreate => write!(f, "Failed to create eventfd"),
         }
     }
 }
@@ -45,7 +47,7 @@ impl StdError for Error {
             XcbReply(e) => Some(e),
             XcbReplyOrId(e) => Some(e),
             XcbConnect(e) => Some(e),
-            Lock | Timeout | Owner | UnexpectedType(_) => None,
+            Lock | Timeout | Owner | UnexpectedType(_) | EventFdCreate => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate x11rb;
+extern crate libc;
 
 pub mod error;
 mod run;
@@ -11,12 +12,14 @@ use std::time::{ Duration, Instant };
 use std::sync::{ Arc, RwLock };
 use std::sync::mpsc::{ Sender, channel };
 use std::collections::HashMap;
+use std::os::fd::AsRawFd;
 use x11rb::connection::{Connection, RequestConnection};
 use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME};
 use x11rb::errors::ConnectError;
 use x11rb::protocol::{Event, xfixes};
 use x11rb::protocol::xproto::{AtomEnum, ConnectionExt, CreateWindowAux, EventMask, Property, WindowClass};
 use error::Error;
+use run::{create_eventfd, EventFd};
 
 pub const INCR_CHUNK_SIZE: usize = 4000;
 const POLL_DURATION: u64 = 50;
@@ -72,9 +75,21 @@ pub struct Clipboard {
     pub getter: Context,
     pub setter: Arc<Context>,
     setmap: SetMap,
-    send: Sender<Atom>
+    send: Sender<Atom>,
+    efd: EventFd,
 }
 
+impl Drop for Clipboard {
+    fn drop(&mut self) {
+        // Need to write any 8 bytes that are not 0 to trigger a read-ready
+        const ANY: &[u8; 8] = &[1, 1, 1, 1, 1, 1, 1, 1];
+        unsafe {
+            // Safety: The FD is valid and owned, the buffer has a static lifetime and is not mutated
+            // Best attempt close stream on thread
+            let _ = libc::write(self.efd.0.as_raw_fd(), ANY.as_ptr() as *const libc::c_void, ANY.len());
+        }
+    }
+}
 pub struct Context {
     pub connection: RustConnection,
     pub screen: usize,
@@ -138,11 +153,13 @@ impl Clipboard {
         let setmap = Arc::new(RwLock::new(HashMap::new()));
         let setmap2 = Arc::clone(&setmap);
 
+        let efd = create_eventfd()?;
+        let efd_c = efd.clone();
         let (sender, receiver) = channel();
         let max_length = setter.connection.maximum_request_bytes();
-        thread::spawn(move || run::run(&setter2, &setmap2, max_length, &receiver));
+        thread::spawn(move || run::run(setter2, setmap2, max_length, receiver, efd_c));
 
-        Ok(Clipboard { getter, setter, setmap, send: sender })
+        Ok(Clipboard { getter, setter, setmap, send: sender, efd })
     }
 
     fn process_event<T>(&self, buff: &mut Vec<u8>, selection: Atom, target: Atom, property: Atom, timeout: T, use_xfixes: bool, sequence_number: u64)

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,11 +2,13 @@ use std::cmp;
 use std::sync::Arc;
 use std::sync::mpsc::{ Receiver, TryRecvError };
 use std::collections::HashMap;
+use std::os::fd::{AsFd, AsRawFd, FromRawFd, OwnedFd};
 use ::{AtomEnum, EventMask};
 use x11rb::connection::Connection;
 use x11rb::protocol::Event;
 use x11rb::protocol::xproto::{Atom, ChangeWindowAttributesAux, ConnectionExt, Property, PropMode, SELECTION_NOTIFY_EVENT, SelectionNotifyEvent, Window};
 use ::{ INCR_CHUNK_SIZE, Context, SetMap };
+use error::Error;
 
 macro_rules! try_continue {
     ( $expr:expr ) => {
@@ -24,123 +26,185 @@ struct IncrState {
     pos: usize
 }
 
-pub fn run(context: &Arc<Context>, setmap: &SetMap, max_length: usize, receiver: &Receiver<Atom>) {
+
+#[derive(Clone)]
+pub(crate) struct EventFd(pub(crate) Arc<OwnedFd>);
+
+pub(crate) fn create_eventfd() -> Result<EventFd, Error>{
+    let event_fd_owned = unsafe {
+        // Docs: https://man7.org/linux/man-pages/man2/eventfd.2.html
+        // Safety: No pointer passing or other spookiness, used correctly according to the above docs
+        let event_fd_res = libc::eventfd(0, libc::EFD_CLOEXEC);
+        // Could check that it's bigger than STDOUT, STDERR, STDIN
+        if event_fd_res < 0 {
+            // Don't want to have to read from errno_location, just skip propagating errno.
+            return Err(Error::EventFdCreate);
+        }
+        // Safety: Trusting the OS to give a correct FD
+        OwnedFd::from_raw_fd(event_fd_res)
+    };
+    Ok(EventFd(Arc::new(event_fd_owned)))
+}
+
+pub fn run(context: Arc<Context>, setmap: SetMap, max_length: usize, receiver: Receiver<Atom>, evt_fd: EventFd) {
     let mut incr_map = HashMap::<Atom, Atom>::new();
     let mut state_map = HashMap::<Atom, IncrState>::new();
 
-
-    while let Ok(event) = context.connection.wait_for_event() {
-        loop {
-            match receiver.try_recv() {
-                Ok(selection) => if let Some(property) = incr_map.remove(&selection) {
-                    state_map.remove(&property);
-                },
-                Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => if state_map.is_empty() {
-                    return
-                }
+    let stream_fd = context.connection.stream().as_fd();
+    let borrowed_fd = evt_fd.0.as_fd();
+    // Poll both stream and eventfd for new Read-ready events
+    let mut pollfds: [libc::pollfd; 2] = [libc::pollfd {
+        fd: stream_fd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    }, libc::pollfd {
+        fd: borrowed_fd.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    }];
+    let len = pollfds.len();
+    loop {
+        unsafe {
+            // Docs: https://man7.org/linux/man-pages/man2/poll.2.html
+            // Safety: Passing in a mutable pointer that lives for the duration of the call, the length is
+            // set to the length of that pointer.
+            // Any negative value (-1 for example) means infinite timeout.
+            let poll_res = libc::poll(&mut pollfds as *mut libc::pollfd, len as libc::nfds_t, -1);
+            if poll_res < 0 {
+                // Error polling, can't continue
+                return;
             }
         }
-
-        match event {
-            Event::SelectionRequest(event) => {
-                let read_map = try_continue!(setmap.read().ok());
-                let &(target, ref value) = try_continue!(read_map.get(&event.selection));
-
-                if event.target == context.atoms.targets {
-                    let _ = x11rb::wrapper::ConnectionExt::change_property32(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        event.requestor,
-                        event.property,
-                        Atom::from(AtomEnum::ATOM),
-                        &[context.atoms.targets, target]
-                    );
-                } else if value.len() < max_length - 24 {
-                    let _ = x11rb::wrapper::ConnectionExt::change_property8(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        event.requestor,
-                        event.property,
-                        target,
-                        value
-                    );
-                } else {
-                    let _ = context.connection.change_window_attributes(
-                        event.requestor,
-                        &ChangeWindowAttributesAux::new()
-                            .event_mask(EventMask::PROPERTY_CHANGE)
-                    );
-                    let _ = x11rb::wrapper::ConnectionExt::change_property32(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        event.requestor,
-                        event.property,
-                        context.atoms.incr,
-                        &[0u32; 0],
-                    );
-                    incr_map.insert(event.selection, event.property);
-                    state_map.insert(
-                        event.property,
-                        IncrState {
-                            selection: event.selection,
-                            requestor: event.requestor,
-                            property: event.property,
-                            pos: 0
-                        }
-                    );
-                }
-                let _ = context.connection.send_event(
-                    false,
-                    event.requestor,
-                    EventMask::default(),
-                    SelectionNotifyEvent {
-                        response_type: SELECTION_NOTIFY_EVENT,
-                        sequence: 0,
-                        time: event.time,
-                        requestor: event.requestor,
-                        selection: event.selection,
-                        target: event.target,
-                        property: event.property
+        if pollfds[1].revents & libc::POLLIN != 0 {
+            // kill-signal on eventfd
+            return;
+        }
+        loop {
+            let evt = if let Ok(evt) = context.connection.poll_for_event() {
+                evt
+            } else {
+                // Connection died, exit
+                return;
+            };
+            let event = if let Some(evt) = evt {
+                evt
+            } else {
+                // No event on POLLIN happens, fd being readable doesn't mean there's a complete event ready to read.
+                // Poll again.
+                break;
+            };
+            loop {
+                match receiver.try_recv() {
+                    Ok(selection) => if let Some(property) = incr_map.remove(&selection) {
+                        state_map.remove(&property);
+                    },
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => if state_map.is_empty() {
+                        return
                     }
-                );
-                let _ = context.connection.flush();
-            },
-            Event::PropertyNotify(event) => {
-                if event.state != Property::DELETE { continue };
-
-                let is_end = {
-                    let state = try_continue!(state_map.get_mut(&event.atom));
-                    let read_setmap = try_continue!(setmap.read().ok());
-                    let &(target, ref value) = try_continue!(read_setmap.get(&state.selection));
-
-                    let len = cmp::min(INCR_CHUNK_SIZE, value.len() - state.pos);
-                    let _ = x11rb::wrapper::ConnectionExt::change_property8(
-                        &context.connection,
-                        PropMode::REPLACE,
-                        state.requestor,
-                        state.property,
-                        target,
-                        &value[state.pos..][..len]
-                    );
-                    state.pos += len;
-                    len == 0
-                };
-
-                if is_end {
-                    state_map.remove(&event.atom);
-                }
-                let _ = context.connection.flush();
-            },
-            Event::SelectionClear(event) => {
-                if let Some(property) = incr_map.remove(&event.selection) {
-                    state_map.remove(&property);
-                }
-                if let Ok(mut write_setmap) = setmap.write() {
-                    write_setmap.remove(&event.selection);
                 }
             }
-            _ => ()
+
+            match event {
+                Event::SelectionRequest(event) => {
+                    let read_map = try_continue!(setmap.read().ok());
+                    let &(target, ref value) = try_continue!(read_map.get(&event.selection));
+
+                    if event.target == context.atoms.targets {
+                        let _ = x11rb::wrapper::ConnectionExt::change_property32(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            Atom::from(AtomEnum::ATOM),
+                            &[context.atoms.targets, target]
+                        );
+                    } else if value.len() < max_length - 24 {
+                        let _ = x11rb::wrapper::ConnectionExt::change_property8(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            target,
+                            value
+                        );
+                    } else {
+                        let _ = context.connection.change_window_attributes(
+                            event.requestor,
+                            &ChangeWindowAttributesAux::new()
+                                .event_mask(EventMask::PROPERTY_CHANGE)
+                        );
+                        let _ = x11rb::wrapper::ConnectionExt::change_property32(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            event.requestor,
+                            event.property,
+                            context.atoms.incr,
+                            &[0u32; 0],
+                        );
+                        incr_map.insert(event.selection, event.property);
+                        state_map.insert(
+                            event.property,
+                            IncrState {
+                                selection: event.selection,
+                                requestor: event.requestor,
+                                property: event.property,
+                                pos: 0
+                            }
+                        );
+                    }
+                    let _ = context.connection.send_event(
+                        false,
+                        event.requestor,
+                        EventMask::default(),
+                        SelectionNotifyEvent {
+                            response_type: SELECTION_NOTIFY_EVENT,
+                            sequence: 0,
+                            time: event.time,
+                            requestor: event.requestor,
+                            selection: event.selection,
+                            target: event.target,
+                            property: event.property
+                        }
+                    );
+                    let _ = context.connection.flush();
+                },
+                Event::PropertyNotify(event) => {
+                    if event.state != Property::DELETE { continue };
+
+                    let is_end = {
+                        let state = try_continue!(state_map.get_mut(&event.atom));
+                        let read_setmap = try_continue!(setmap.read().ok());
+                        let &(target, ref value) = try_continue!(read_setmap.get(&state.selection));
+
+                        let len = cmp::min(INCR_CHUNK_SIZE, value.len() - state.pos);
+                        let _ = x11rb::wrapper::ConnectionExt::change_property8(
+                            &context.connection,
+                            PropMode::REPLACE,
+                            state.requestor,
+                            state.property,
+                            target,
+                            &value[state.pos..][..len]
+                        );
+                        state.pos += len;
+                        len == 0
+                    };
+
+                    if is_end {
+                        state_map.remove(&event.atom);
+                    }
+                    let _ = context.connection.flush();
+                },
+                Event::SelectionClear(event) => {
+                    if let Some(property) = incr_map.remove(&event.selection) {
+                        state_map.remove(&property);
+                    }
+                    if let Ok(mut write_setmap) = setmap.write() {
+                        write_setmap.remove(&event.selection);
+                    }
+                }
+                _ => ()
+            }
         }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/quininer/x11-clipboard/pull/43 scrapping formatting, using `libc` over `nix`

The changes are a bit more clean since there's no reformat, although indentation changes because of having to wrap some logic in a new loop.

The changes now require* unsafe interfacing with `libc` in three places.