### PR TITLE
Change fn visibility to reduce `MSRV` from `1.74` to `1.66`

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -46,7 +46,7 @@ pub(crate) fn create_eventfd() -> Result<EventFd, Error>{
     Ok(EventFd(Arc::new(event_fd_owned)))
 }
 
-pub fn run(context: Arc<Context>, setmap: SetMap, max_length: usize, receiver: Receiver<Atom>, evt_fd: EventFd) {
+pub(crate) fn run(context: Arc<Context>, setmap: SetMap, max_length: usize, receiver: Receiver<Atom>, evt_fd: EventFd) {
     let mut incr_map = HashMap::<Atom, Atom>::new();
     let mut state_map = HashMap::<Atom, IncrState>::new();
 


### PR DESCRIPTION
Thanks a lot for publishing `0.9.0`!

That version has an issue that makes it require rust `1.74` - on earlier versions the build fails with:

> error[E0446]: crate-private type `EventFd` in public interface
  --> src/run.rs:49:1
   |
31 | pub(crate) struct EventFd(pub(crate) Arc<OwnedFd>);
   | ------------------------- `EventFd` declared as crate-private
...
49 | pub fn run(context: Arc<Context>, setmap: SetMap, max_length: usize, receiver: Receiver<Atom>, evt_fd: EventFd) {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type

This PR lowers the `MSRV` to `1.66` (where `std::os::fd` was introduced) - if possible it would be nice with a `0.9.1` including it!