### PR TITLE
Use `pipe` instead of `eventfd` for unix compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x11-clipboard"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["quininer kel <quininer@live.com>"]
 description = "x11 clipboard support for Rust."
 repository = "https://github.com/quininer/x11-clipboard"

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     Timeout,
     Owner,
     UnexpectedType(Atom),
+    // Could change name on next major, since this uses pipes now.
     EventFdCreate,
 }
 


### PR DESCRIPTION
Fixes https://github.com/quininer/x11-clipboard/issues/48

Changes use from Linux-specific `eventfd` to `poll` and `pipe` which are POSIX.

Ran same tests as with https://github.com/quininer/x11-clipboard/pull/43 to check for regressions.

Also ran https://github.com/obi1kenobi/cargo-semver-checks to check for no major version changes.
Sadly, renaming the error causes a major version change, I'll leave it up to you if it's worth it to change that name.

Since the read and write pipes are separate `fd`s, there's no need for an `Arc` and the write-end will be dropped with the Clipboard, Clipboard therefore doesn't need to implement drop and can rely on `OwnedFd`s drop, which closes the underlying `fd`.