### PR TITLE
Remove racy selection ownership verification from store

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,14 +372,6 @@ impl Clipboard {
             CURRENT_TIME
         )?.check()?;
 
-        if self.setter.connection.get_selection_owner(
-            selection
-        )?.reply()
-            .map(|reply| reply.owner == self.setter.window)
-            .unwrap_or(false) {
-            Ok(())
-        } else {
-            Err(Error::Owner)
-        }
+        Ok(())
     }
 }


### PR DESCRIPTION
The `store()` function verified ownership by calling `get_selection_owner()` after `set_selection_owner()`. However, the `.check()` on the latter introduces a synchronization round-trip, during which the X server dispatches `SelectionClear` to previous owners and `XFixes` notifications to watchers. This gives clipboard managers enough time to grab the content and re-claim ownership before `get_selection_owner()` is even invoked, causing a spurious `Error::Owner` failure despite the store having actually succeeded.

The ownership verification is fundamentally flawed: `set_selection_owner()` with `CURRENT_TIME` always succeeds unless the window is invalid (which would be a bug). As such, remove the owner check to prevent emitting spurious errors.

This fixes a long-time issue in alacritty [0].

[0] https://github.com/alacritty/alacritty/issues/6978